### PR TITLE
feat: Display all reviews from all races on dashboard page

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-navigation-menu": "^1.2.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.10
+        version: 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.15
         version: 2.1.15(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -428,6 +431,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
@@ -680,6 +696,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1793,6 +1818,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vite@7.0.0:
     resolution: {integrity: sha512-ixXJB1YRgDIw2OszKQS9WxGHKwLdCsbQNkpJN171udl6szi/rIySHL6/Os3s2+oE4P/FLD4dxg4mD7Wust+u5g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2111,6 +2141,19 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
@@ -2375,6 +2418,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.8
 
@@ -3391,6 +3441,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.8
+
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   vite@7.0.0(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1):
     dependencies:

--- a/src/components/dashboard-page.tsx
+++ b/src/components/dashboard-page.tsx
@@ -91,7 +91,7 @@ export function DashboardPage() {
             Browse reviews from all Formula 1 races
           </p>
         </header>
-        <Alert variant="destructive">
+        <Alert variant="destructive" data-testid="error-alert">
           <AlertDescription>
             Failed to load reviews. Please try refreshing the page.
           </AlertDescription>

--- a/src/components/dashboard-page.tsx
+++ b/src/components/dashboard-page.tsx
@@ -1,7 +1,99 @@
+import { useMemo } from "react";
+import { useReviews, useRaces } from "@/lib/queries";
+import { Loader2 } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import ReviewListItem from "@/components/review-list-item";
+import type { Race } from "@/lib/types";
+
 export function DashboardPage() {
+  const { data: reviews, isLoading: reviewsLoading, error: reviewsError } = useReviews();
+  const { data: races, isLoading: racesLoading, error: racesError } = useRaces();
+
+  // Create a map of race IDs to race names for quick lookup
+  const raceMap = useMemo(() => {
+    const map = new Map<string, Race>();
+    races?.forEach((race) => {
+      map.set(race.id, race);
+    });
+    return map;
+  }, [races]);
+
+  // Combine reviews with race information and sort by date (newest first)
+  const reviewsWithRaceInfo = useMemo(() => {
+    return reviews?.map((review) => ({
+      ...review,
+      raceName: review.raceId ? raceMap.get(review.raceId)?.name : undefined,
+    }))
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()) || [];
+  }, [reviews, raceMap]);
+
+  const isLoading = reviewsLoading || racesLoading;
+  const error = reviewsError || racesError;
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto max-w-2xl p-4 space-y-8">
+        <header>
+          <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl text-center">
+            All Reviews
+          </h1>
+          <p className="text-center text-muted-foreground mt-2">
+            Loading reviews from all races...
+          </p>
+        </header>
+        <div className="flex justify-center items-center py-8">
+          <Loader2 className="animate-spin h-8 w-8" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto max-w-2xl p-4 space-y-8">
+        <header>
+          <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl text-center">
+            All Reviews
+          </h1>
+          <p className="text-center text-muted-foreground mt-2">
+            Browse reviews from all Formula 1 races
+          </p>
+        </header>
+        <Alert variant="destructive">
+          <AlertDescription>
+            Failed to load reviews. Please try refreshing the page.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-col items-center justify-center h-screen">
-      <h1 className="text-4xl font-bold">Dashboard</h1>
+    <div className="container mx-auto max-w-2xl p-4 space-y-8">
+      <header>
+        <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl text-center">
+          All Reviews
+        </h1>
+        <p className="text-center text-muted-foreground mt-2">
+          Browse reviews from all Formula 1 races
+        </p>
+      </header>
+      
+      {reviewsWithRaceInfo.length === 0 ? (
+        <div className="flex justify-center items-center py-8">
+          <p className="text-muted-foreground">No reviews yet. Be the first to review a race!</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {reviewsWithRaceInfo.map((review) => (
+            <ReviewListItem
+              key={review.id}
+              review={review}
+              raceName={review.raceName}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/review-list-item.tsx
+++ b/src/components/review-list-item.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 import type { Review } from "../lib/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { formatRelativeTime, formatHoverDate } from "@/lib/utils";
 import HeartIcon from "@/components/ui/heart-icon";
 import { useLikeReview } from "@/lib/queries";
 import { authClient } from "@/lib/auth-client";
+import { Link } from "react-router-dom";
 
 type ReviewListItemProps = {
   review: Review;
+  raceName?: string;
 };
 
 const StarIcon = (props: React.SVGProps<SVGSVGElement>) => (
@@ -27,7 +30,7 @@ const StarIcon = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
-const ReviewListItem = ({ review }: ReviewListItemProps) => {
+const ReviewListItem = ({ review, raceName }: ReviewListItemProps) => {
   const session = authClient.useSession();
   const likeMutation = useLikeReview();
 
@@ -43,15 +46,25 @@ const ReviewListItem = ({ review }: ReviewListItemProps) => {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center gap-4">
-        <img
-          src={review.avatarUrl}
-          alt={review.author}
-          className="w-12 h-12 rounded-full"
-          referrerPolicy="no-referrer"
-          crossOrigin="anonymous"
-        />
+        <Avatar className="w-12 h-12">
+          <AvatarImage 
+            src={review.avatarUrl} 
+            alt={review.author}
+            referrerPolicy="no-referrer"
+            crossOrigin="anonymous"
+          />
+          <AvatarFallback>{review.author[0]?.toUpperCase()}</AvatarFallback>
+        </Avatar>
         <div className="flex-1">
           <CardTitle>{review.author}</CardTitle>
+          {raceName && review.raceId && (
+            <Link 
+              to={`/race/${review.raceId}`} 
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {raceName}
+            </Link>
+          )}
           <p
             className="text-sm text-gray-500 dark:text-muted-foreground cursor-help"
             title={formatHoverDate(review.date)}

--- a/src/components/review-list-item.tsx
+++ b/src/components/review-list-item.tsx
@@ -50,7 +50,7 @@ const ReviewListItem = ({ review, raceName }: ReviewListItemProps) => {
   };
 
   return (
-    <Card>
+    <Card data-testid="review-item">
       <CardHeader className="flex flex-row items-center gap-4">
         <Avatar className="w-12 h-12">
           <AvatarImage 

--- a/src/components/review-list-item.tsx
+++ b/src/components/review-list-item.tsx
@@ -34,6 +34,12 @@ const ReviewListItem = ({ review, raceName }: ReviewListItemProps) => {
   const session = authClient.useSession();
   const likeMutation = useLikeReview();
 
+  // Validate review data
+  if (!review || !review.author) {
+    console.error('Invalid review data provided to ReviewListItem');
+    return null;
+  }
+
   const handleLike = () => {
     if (!session.data?.user || !review.id) return;
     
@@ -53,7 +59,9 @@ const ReviewListItem = ({ review, raceName }: ReviewListItemProps) => {
             referrerPolicy="no-referrer"
             crossOrigin="anonymous"
           />
-          <AvatarFallback>{review.author[0]?.toUpperCase()}</AvatarFallback>
+          {/* When the author's name is missing, use X as the fallback. */}
+          {/* Why X? - x is unknown - math nerd joke */}
+          <AvatarFallback>{review.author?.charAt(0)?.toUpperCase() || 'X'}</AvatarFallback>
         </Avatar>
         <div className="flex-1">
           <CardTitle>{review.author}</CardTitle>

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+));
+Alert.displayName = "Alert";
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+AlertTitle.displayName = "AlertTitle";
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+));
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertTitle, AlertDescription };

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+import { cn } from "@/lib/utils";
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName;
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+));
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -1,0 +1,477 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Dashboard Page', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock Better Auth session endpoint to simulate authenticated user
+    await page.route('**/api/auth/get-session', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          user: { 
+            id: 'test-user', 
+            name: 'Test User', 
+            email: 'test@example.com' 
+          },
+          session: { 
+            id: 'test-session',
+            userId: 'test-user',
+            expiresAt: new Date(Date.now() + 86400000).toISOString()
+          }
+        })
+      });
+    });
+  });
+
+  test.describe('Page Structure', () => {
+    test('should display the correct header and subtitle with mixed data', async ({ page }) => {
+      // Mock successful API responses with mixed data
+      const mockRaces = [
+        { id: '1', name: 'Monaco Grand Prix', date: '2024-05-26', circuit: 'Circuit de Monaco' },
+        { id: '2', name: 'Canadian Grand Prix', date: '2024-06-09', circuit: 'Circuit Gilles Villeneuve' }
+      ];
+
+      const mockReviews = [
+        {
+          id: 'r1',
+          raceId: '1',
+          userId: 'u1',
+          rating: 5,
+          comment: 'Amazing race with great overtakes!',
+          date: '2024-05-27T10:00:00Z',
+          likeCount: 10,
+          author: 'John Doe',
+          text: 'Amazing race with great overtakes!',
+          isLikedByUser: false
+        },
+        {
+          id: 'r2',
+          raceId: '2',
+          userId: 'u2',
+          rating: 4,
+          comment: 'Great strategy battles throughout',
+          date: '2024-06-10T15:00:00Z',
+          likeCount: 5,
+          author: 'Jane Smith',
+          text: 'Great strategy battles throughout',
+          isLikedByUser: true
+        }
+      ];
+
+      await page.route('**/api/races', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockRaces)
+        });
+      });
+
+      await page.route('**/api/reviews', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockReviews)
+        });
+      });
+
+      await page.goto('/');
+      
+      // Wait for content to load
+      await page.waitForSelector('h1', { timeout: 10000 });
+      
+      const heading = page.getByRole('heading', { name: 'All Reviews' });
+      await expect(heading).toBeVisible();
+      
+      const subtitle = page.getByText('Browse reviews from all Formula 1 races');
+      await expect(subtitle).toBeVisible();
+    });
+
+    test('should have proper container styling', async ({ page }) => {
+      // Mock empty responses for basic structure test
+      await page.route('**/api/races', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([])
+        });
+      });
+
+      await page.route('**/api/reviews', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([])
+        });
+      });
+
+      await page.goto('/');
+      
+      await page.waitForSelector('h1', { timeout: 10000 });
+      // Target the specific dashboard container with space-y-8 class which is unique
+      const container = page.locator('.container.mx-auto.max-w-2xl.p-4.space-y-8');
+      await expect(container).toBeVisible();
+    });
+  });
+
+  test.describe('Error State', () => {
+    test('should display error message when API fails', async ({ page }) => {
+      // Simulate API error
+      await page.route('**/api/reviews', route => {
+        route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Internal Server Error' })
+        });
+      });
+
+      await page.route('**/api/races', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([])
+        });
+      });
+
+      await page.goto('/');
+      
+      // Wait for error to appear
+      await page.waitForSelector('[data-testid="error-alert"]', { timeout: 10000 });
+      
+      const errorMessage = page.getByText('Failed to load reviews. Please try refreshing the page.');
+      await expect(errorMessage).toBeVisible();
+    });
+  });
+
+  test.describe('Empty State', () => {
+    test('should display empty state message when no reviews exist', async ({ page }) => {
+      // Mock empty reviews response
+      await page.route('**/api/reviews', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([])
+        });
+      });
+
+      await page.route('**/api/races', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([])
+        });
+      });
+
+      await page.goto('/');
+      
+      await page.waitForSelector('h1', { timeout: 10000 });
+      
+      const emptyMessage = page.getByText('No reviews yet. Be the first to review a race!');
+      await expect(emptyMessage).toBeVisible();
+    });
+  });
+
+  test.describe('Reviews Display and Sorting', () => {
+    test('should display reviews sorted by date with newest first', async ({ page }) => {
+      const mockRaces = [
+        { id: '1', name: 'Monaco Grand Prix', date: '2024-05-26', circuit: 'Circuit de Monaco' }
+      ];
+
+      // Create reviews with different dates to test sorting
+      const mockReviews = [
+        {
+          id: 'r1',
+          raceId: '1',
+          userId: 'u1',
+          rating: 5,
+          comment: 'Older review from May 20th',
+          date: '2024-05-20T10:00:00Z',
+          likeCount: 10,
+          author: 'John Doe',
+          text: 'Older review from May 20th',
+          isLikedByUser: false
+        },
+        {
+          id: 'r2',
+          raceId: '1',
+          userId: 'u2',
+          rating: 4,
+          comment: 'Newer review from May 25th',
+          date: '2024-05-25T15:00:00Z',
+          likeCount: 5,
+          author: 'Jane Smith',
+          text: 'Newer review from May 25th',
+          isLikedByUser: true
+        }
+      ];
+
+      await page.route('**/api/races', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockRaces)
+        });
+      });
+
+      await page.route('**/api/reviews', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockReviews)
+        });
+      });
+
+      await page.goto('/');
+      
+      // Wait for reviews to load
+      await page.waitForSelector('[data-testid="review-item"]', { timeout: 10000 });
+      
+      const reviewItems = page.locator('[data-testid="review-item"]');
+      await expect(reviewItems).toHaveCount(2);
+      
+      // Check that newer review appears first (review sorting by date)
+      const firstReviewText = await reviewItems.first().textContent();
+      expect(firstReviewText).toContain('Newer review from May 25th');
+    });
+
+    test('should handle reviews with missing race data gracefully', async ({ page }) => {
+      const mockRaces = [
+        { id: '1', name: 'Monaco Grand Prix', date: '2024-05-26', circuit: 'Circuit de Monaco' }
+      ];
+
+      const mockReviews = [
+        {
+          id: 'r1',
+          raceId: '1',
+          userId: 'u1',
+          rating: 5,
+          comment: 'Review with valid race',
+          date: '2024-05-27T10:00:00Z',
+          likeCount: 10,
+          author: 'John Doe',
+          text: 'Review with valid race',
+          isLikedByUser: false
+        },
+        {
+          id: 'r2',
+          raceId: '999', // Non-existent race ID
+          userId: 'u2',
+          rating: 4,
+          comment: 'Review with invalid race ID',
+          date: '2024-06-10T15:00:00Z',
+          likeCount: 5,
+          author: 'Jane Smith',
+          text: 'Review with invalid race ID',
+          isLikedByUser: false
+        }
+      ];
+
+      await page.route('**/api/races', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockRaces)
+        });
+      });
+
+      await page.route('**/api/reviews', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockReviews)
+        });
+      });
+
+      await page.goto('/');
+      
+      // Wait for reviews to load
+      await page.waitForSelector('[data-testid="review-item"]', { timeout: 10000 });
+      
+      // Both reviews should still be displayed even with missing race data
+      const reviewItems = page.locator('[data-testid="review-item"]');
+      await expect(reviewItems).toHaveCount(2);
+      
+      // Verify the valid race has a clickable link
+      const validRaceLink = page.locator('a').filter({ hasText: 'Monaco Grand Prix' });
+      await expect(validRaceLink).toBeVisible();
+    });
+  });
+
+  test.describe('Race Name Links', () => {
+    test('should make race names clickable links that work properly', async ({ page }) => {
+      const mockRaces = [
+        { id: '1', name: 'Monaco Grand Prix', date: '2024-05-26', circuit: 'Circuit de Monaco' }
+      ];
+
+      const mockReviews = [
+        {
+          id: 'r1',
+          raceId: '1',
+          userId: 'u1',
+          rating: 5,
+          comment: 'Amazing Monaco race!',
+          date: '2024-05-27T10:00:00Z',
+          likeCount: 10,
+          author: 'John Doe',
+          text: 'Amazing Monaco race!',
+          isLikedByUser: false
+        }
+      ];
+
+      await page.route('**/api/races', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockRaces)
+        });
+      });
+
+      await page.route('**/api/reviews', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockReviews)
+        });
+      });
+
+      await page.goto('/');
+      
+      // Wait for reviews to load
+      await page.waitForSelector('[data-testid="review-item"]', { timeout: 10000 });
+      
+      // Find the race name link
+      const raceLink = page.locator('a').filter({ hasText: 'Monaco Grand Prix' });
+      await expect(raceLink).toBeVisible();
+      
+      // Check that it has the correct href
+      const href = await raceLink.getAttribute('href');
+      expect(href).toBe('/race/1');
+    });
+
+    test('should navigate to race page when race name is clicked', async ({ page }) => {
+      const mockRaces = [
+        { id: '1', name: 'Monaco Grand Prix', date: '2024-05-26', circuit: 'Circuit de Monaco' }
+      ];
+
+      const mockReviews = [
+        {
+          id: 'r1',
+          raceId: '1',
+          userId: 'u1',
+          rating: 5,
+          comment: 'Great race at Monaco!',
+          date: '2024-05-27T10:00:00Z',
+          likeCount: 10,
+          author: 'John Doe',
+          text: 'Great race at Monaco!',
+          isLikedByUser: false
+        }
+      ];
+
+      await page.route('**/api/races', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockRaces)
+        });
+      });
+
+      await page.route('**/api/reviews', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockReviews)
+        });
+      });
+
+      await page.goto('/');
+      
+      // Wait for reviews to load
+      await page.waitForSelector('[data-testid="review-item"]', { timeout: 10000 });
+      
+      // Click on race name
+      const raceLink = page.locator('a').filter({ hasText: 'Monaco Grand Prix' });
+      await raceLink.click();
+      
+      // Should navigate to race page
+      await expect(page).toHaveURL('/race/1');
+    });
+  });
+
+  test.describe('Accessibility', () => {
+    test('should have proper heading hierarchy', async ({ page }) => {
+      await page.route('**/api/races', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([])
+        });
+      });
+
+      await page.route('**/api/reviews', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([])
+        });
+      });
+
+      await page.goto('/');
+      
+      await page.waitForSelector('h1', { timeout: 10000 });
+      
+      // Main heading should be h1
+      const h1 = page.locator('h1');
+      await expect(h1).toHaveText('All Reviews');
+      
+      // Should only have one h1
+      await expect(h1).toHaveCount(1);
+    });
+
+    test('should have proper focus states for interactive elements', async ({ page }) => {
+      const mockRaces = [
+        { id: '1', name: 'Monaco Grand Prix', date: '2024-05-26', circuit: 'Circuit de Monaco' }
+      ];
+
+      const mockReviews = [
+        {
+          id: 'r1',
+          raceId: '1',
+          userId: 'u1',
+          rating: 5,
+          comment: 'Accessible review test',
+          date: '2024-05-27T10:00:00Z',
+          likeCount: 10,
+          author: 'John Doe',
+          text: 'Accessible review test',
+          isLikedByUser: false
+        }
+      ];
+
+      await page.route('**/api/races', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockRaces)
+        });
+      });
+
+      await page.route('**/api/reviews', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockReviews)
+        });
+      });
+
+      await page.goto('/');
+      
+      // Wait for reviews to load
+      await page.waitForSelector('[data-testid="review-item"]', { timeout: 10000 });
+      
+      // Check for proper focus states
+      const firstLink = page.locator('a').first();
+      await firstLink.focus();
+      await expect(firstLink).toBeFocused();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement dashboard page to display all reviews from all races
- Add race name information to each review card
- Improve user experience with sorted reviews and optimized performance

## Changes
- Updated dashboard page to fetch both reviews and races data
- Modified ReviewListItem component to optionally display race name with link
- Added Avatar component from shadcn/ui for better user avatars
- Added Alert component from shadcn/ui for error states
- Sorted reviews by date (newest first)
- Optimized performance using useMemo hooks
- Fixed React hooks order to prevent runtime errors

## Screenshots
The dashboard now displays all reviews with the race name shown below the author's name as a clickable link.

## Test Plan
- [x] Dashboard page loads all reviews from all races
- [x] Each review shows the race name with a working link
- [x] Reviews are sorted by date (newest first)
- [x] Loading and error states display correctly
- [x] No React hooks errors
- [x] Google profile images load correctly with Avatar component

Closes #5