### PR TITLE
feat: Add manage account page with delete functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ npm run test:ui    # Run Playwright tests with UI mode
 
 ## Architecture Overview
 
-This is a React + TypeScript frontend for a Formula 1 Grand Prix review application, using:
+This is a React + TypeScript frontend for a FORMULA 1 Grand Prix review application, using:
 - **Vite** as the build tool with SWC for fast compilation
 - **React Query (TanStack Query)** for server state management
 - **Better Auth** for authentication with OAuth support

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
@@ -23,6 +24,7 @@
     "better-auth": "^1.2.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.525.0",
+    "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "6.30.1",
+    "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.11"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.14
+        version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.10
         version: 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -41,6 +44,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@19.1.0)
@@ -418,6 +424,19 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/react-alert-dialog@1.1.14':
+    resolution: {integrity: sha512-IOZfZ3nPvN6lXpJTBCunFQPRSvK8MDgSc1FB85xnIpUKOw9en0dJj8JmCAxV7BiZdtYlUpmrQjoTFkVYtdoWzQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -473,6 +492,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.14':
+    resolution: {integrity: sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-direction@1.1.1':
@@ -1214,6 +1246,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -2132,6 +2167,20 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/react-alert-dialog@1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2177,6 +2226,28 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
+
+  '@radix-ui/react-dialog@1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.1(@types/react@19.1.8)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
   '@radix-ui/react-direction@1.1.1(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
@@ -2883,6 +2954,8 @@ snapshots:
       which: 2.0.2
 
   csstype@3.1.3: {}
+
+  date-fns@4.1.0: {}
 
   debug@4.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@19.1.0)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -59,6 +62,9 @@ importers:
       react-router-dom:
         specifier: 6.30.1
         version: 6.30.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      sonner:
+        specifier: ^2.0.6
+        version: 2.0.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -1605,6 +1611,12 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1761,6 +1773,12 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  sonner@2.0.6:
+    resolution: {integrity: sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3285,6 +3303,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3435,6 +3458,11 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  sonner@2.0.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   source-map-js@1.2.1: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Header } from "./components/layout/header";
 import { Footer } from "./components/layout/footer";
 import { ProtectedRoute } from "./components/protected-route";
 import GrandPrixReviewPage from "./components/grand-prix-review-page";
+import { ManageAccountPage } from "./components/manage-account-page";
 
 function App() {
   return (
@@ -18,6 +19,14 @@ function App() {
               element={
                 <ProtectedRoute>
                   <GrandPrixReviewPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/manage-account"
+              element={
+                <ProtectedRoute>
+                  <ManageAccountPage />
                 </ProtectedRoute>
               }
             />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Footer } from "./components/layout/footer";
 import { ProtectedRoute } from "./components/protected-route";
 import GrandPrixReviewPage from "./components/grand-prix-review-page";
 import { ManageAccountPage } from "./components/manage-account-page";
+import { Toaster } from "./components/ui/sonner";
 
 function App() {
   return (
@@ -33,6 +34,7 @@ function App() {
           </Routes>
         </main>
         <Footer />
+        <Toaster />
       </div>
     </BrowserRouter>
   );

--- a/src/components/auth/user-menu.tsx
+++ b/src/components/auth/user-menu.tsx
@@ -1,4 +1,4 @@
-import { LogOut, User } from "lucide-react";
+import { LogOut, Settings } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -9,14 +9,15 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { authClient } from "@/lib/auth-client";
 import type { User as UserType } from "@/lib/types";
-import { useState } from "react";
+import { UserAvatar } from "@/components/ui/user-avatar";
+import { useNavigate } from "react-router-dom";
 
 interface UserMenuProps {
   user: UserType;
 }
 
 export function UserMenu({ user }: UserMenuProps) {
-  const [imageError, setImageError] = useState(false);
+  const navigate = useNavigate();
   
   const handleSignOut = async () => {
     try {
@@ -30,41 +31,20 @@ export function UserMenu({ user }: UserMenuProps) {
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" className="relative h-8 w-8 rounded-full p-0">
-          {user.image && !imageError ? (
-            <img
-              className="h-8 w-8 rounded-full object-cover"
-              src={user.image}
-              alt={user.name || "User avatar"}
-              onError={() => {
-                console.error("Failed to load image:", user.image);
-                setImageError(true);
-              }}
-              loading="lazy"
-              referrerPolicy="no-referrer"
-              crossOrigin="anonymous"
-            />
-          ) : (
-            <User className="h-5 w-5" />
-          )}
+          <UserAvatar 
+            name={user.name}
+            image={user.image}
+            className="h-8 w-8"
+          />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56" align="end" forceMount>
         <div className="flex items-center justify-start gap-2 p-2">
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
-            {user.image && !imageError ? (
-              <img
-                className="h-10 w-10 rounded-full object-cover"
-                src={user.image}
-                alt={user.name || "User avatar"}
-                onError={() => setImageError(true)}
-                loading="lazy"
-                referrerPolicy="no-referrer"
-                crossOrigin="anonymous"
-              />
-            ) : (
-              <User className="h-5 w-5" />
-            )}
-          </div>
+          <UserAvatar 
+            name={user.name}
+            image={user.image}
+            className="h-10 w-10"
+          />
           <div className="flex flex-col space-y-1 leading-none">
             {user.name && <p className="font-medium">{user.name}</p>}
             {user.email && (
@@ -75,6 +55,13 @@ export function UserMenu({ user }: UserMenuProps) {
           </div>
         </div>
         <DropdownMenuSeparator />
+        <DropdownMenuItem 
+          className="cursor-pointer" 
+          onSelect={() => navigate("/manage-account")}
+        >
+          <Settings className="mr-2 h-4 w-4" />
+          <span>Manage Account</span>
+        </DropdownMenuItem>
         <DropdownMenuItem className="cursor-pointer" onSelect={handleSignOut}>
           <LogOut className="mr-2 h-4 w-4" />
           <span>Sign out</span>

--- a/src/components/dashboard-page.tsx
+++ b/src/components/dashboard-page.tsx
@@ -88,7 +88,7 @@ export function DashboardPage() {
             All Reviews
           </h1>
           <p className="text-center text-muted-foreground mt-2">
-            Browse reviews from all Formula 1 races
+            Browse reviews from all FORMULA 1 races
           </p>
         </header>
         <Alert variant="destructive" data-testid="error-alert">
@@ -107,7 +107,7 @@ export function DashboardPage() {
           All Reviews
         </h1>
         <p className="text-center text-muted-foreground mt-2">
-          Browse reviews from all Formula 1 races
+          Browse reviews from all FORMULA 1 races
         </p>
       </header>
       

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -41,7 +41,7 @@ export function HomePage() {
                 Welcome to BoxBox BoxBox
               </CardTitle>
               <CardDescription className="text-base">
-                Your ultimate destination for Formula 1 Grand Prix reviews &
+                Your ultimate destination for FORMULA 1 Grand Prix reviews &
                 ratings
               </CardDescription>
             </CardHeader>
@@ -57,7 +57,7 @@ export function HomePage() {
                   Sign In to Get Started
                 </Button>
                 <p className="text-xs text-center text-muted-foreground">
-                  Sign in with Google to access all features
+                  Sign in to access all features
                 </p>
               </div>
             </CardContent>

--- a/src/components/manage-account-page.tsx
+++ b/src/components/manage-account-page.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { authClient } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Calendar, Mail } from "lucide-react";
+import { UserAvatar } from "@/components/ui/user-avatar";
+import { useDeleteAccount } from "@/lib/queries";
+import { format } from "date-fns";
+
+export function ManageAccountPage() {
+  const navigate = useNavigate();
+  const { data: session } = authClient.useSession();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const deleteAccountMutation = useDeleteAccount();
+
+  if (!session?.user) {
+    return null;
+  }
+
+  const handleDeleteAccount = async () => {
+    try {
+      await deleteAccountMutation.mutateAsync(session.user.id);
+      navigate("/");
+    } catch (error) {
+      console.error("Failed to delete account:", error);
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-2xl px-4 py-8">
+      <h1 className="text-3xl font-bold mb-8">Manage Account</h1>
+
+      <div className="space-y-6">
+        {/* Account Information */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Account Information</CardTitle>
+            <CardDescription>Your personal account details</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center space-x-4">
+              <UserAvatar 
+                name={session.user.name}
+                image={session.user.image}
+                className="h-16 w-16"
+              />
+              <div className="space-y-1">
+                <h3 className="text-lg font-medium">{session.user.name}</h3>
+                <div className="flex items-center text-sm text-muted-foreground">
+                  <Mail className="mr-1 h-3 w-3" />
+                  {session.user.email}
+                </div>
+              </div>
+            </div>
+
+            <div className="pt-4 border-t">
+              <div className="flex items-center text-sm text-muted-foreground">
+                <Calendar className="mr-2 h-4 w-4" />
+                Member since {format(new Date(session.user.createdAt), "MMMM d, yyyy")}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Delete Account */}
+        <Card className="border-destructive/50">
+          <CardHeader>
+            <CardTitle className="text-destructive">Delete Account</CardTitle>
+            <CardDescription>
+              Permanently delete your account and all associated data
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground mb-4">
+              Once you delete your account, there is no going back. Please be certain.
+            </p>
+            <Button
+              variant="destructive"
+              onClick={() => setShowDeleteDialog(true)}
+              disabled={deleteAccountMutation.isPending}
+            >
+              Delete Account
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This will permanently delete your account
+              and remove all of your data including your reviews and ratings.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteAccount}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete Account
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/manage-account-page.tsx
+++ b/src/components/manage-account-page.tsx
@@ -5,7 +5,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -13,7 +12,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Calendar, Mail, RotateCcw } from "lucide-react";
+import { Calendar, Mail } from "lucide-react";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { useDeleteAccount } from "@/lib/queries";
 import { format } from "date-fns";
@@ -212,26 +211,16 @@ export function ManageAccountPage() {
               Cancel
             </AlertDialogCancel>
             
-            {/* Show retry button for recoverable errors */}
-            {lastError?.isRecoverable && (
-              <Button
-                variant="outline"
-                onClick={handleDeleteAccount}
-                disabled={deleteAccountMutation.isPending}
-                className="mr-2"
-              >
-                <RotateCcw className="mr-2 h-4 w-4" />
-                {deleteAccountMutation.isPending ? "Retrying..." : "Retry"}
-              </Button>
-            )}
-            
-            <AlertDialogAction
+            <Button
+              variant="destructive"
               onClick={handleDeleteAccount}
               disabled={deleteAccountMutation.isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              {deleteAccountMutation.isPending ? "Deleting..." : "Delete Account"}
-            </AlertDialogAction>
+              {deleteAccountMutation.isPending 
+                ? (lastError?.isRecoverable ? "Retrying..." : "Deleting...")
+                : (lastError?.isRecoverable ? "Retry Deletion" : "Delete Account")
+              }
+            </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/components/manage-account-page.tsx
+++ b/src/components/manage-account-page.tsx
@@ -89,6 +89,7 @@ export function ManageAccountPage() {
     setLastError(null);
     
     try {
+      // backend checks that only the logged in user can delete their own account
       await deleteAccountMutation.mutateAsync(session.user.id);
       toast.success("Account successfully deleted");
       

--- a/src/components/manage-account-page.tsx
+++ b/src/components/manage-account-page.tsx
@@ -13,15 +13,72 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Calendar, Mail } from "lucide-react";
+import { Calendar, Mail, RotateCcw } from "lucide-react";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { useDeleteAccount } from "@/lib/queries";
 import { format } from "date-fns";
+import { toast } from "sonner";
+import { ApiError } from "@/lib/api";
+
+// Error categorization helper
+function categorizeError(error: unknown): { message: string; isRecoverable: boolean; shouldCloseDialog: boolean } {
+  // Network errors
+  if (error instanceof Error && error.message.includes('Network error')) {
+    return {
+      message: error.message,
+      isRecoverable: true,
+      shouldCloseDialog: false
+    };
+  }
+
+  // API errors with status codes
+  if (error instanceof ApiError) {
+    if (error.status === 401 || error.status === 403) {
+      return {
+        message: "Your session has expired. Please sign in again.",
+        isRecoverable: false,
+        shouldCloseDialog: true
+      };
+    }
+    
+    if (error.status >= 500) {
+      return {
+        message: error.serverMessage || "Server error. Please try again later or contact support.",
+        isRecoverable: true,
+        shouldCloseDialog: false
+      };
+    }
+    
+    if (error.status === 404) {
+      return {
+        message: "Account not found. Please refresh the page and try again.",
+        isRecoverable: false,
+        shouldCloseDialog: true
+      };
+    }
+    
+    // Other client errors (400, etc.)
+    return {
+      message: error.serverMessage || "Invalid request. Please refresh and try again.",
+      isRecoverable: false,
+      shouldCloseDialog: true
+    };
+  }
+
+  // Generic error fallback
+  const message = error instanceof Error ? error.message : "An unexpected error occurred. Please try again.";
+  return {
+    message,
+    isRecoverable: true,
+    shouldCloseDialog: false
+  };
+}
 
 export function ManageAccountPage() {
   const navigate = useNavigate();
   const { data: session } = authClient.useSession();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [lastError, setLastError] = useState<{ message: string; isRecoverable: boolean } | null>(null);
   const deleteAccountMutation = useDeleteAccount();
 
   if (!session?.user) {
@@ -29,12 +86,40 @@ export function ManageAccountPage() {
   }
 
   const handleDeleteAccount = async () => {
+    setLastError(null);
+    
     try {
       await deleteAccountMutation.mutateAsync(session.user.id);
-      await authClient.signOut();
-      navigate("/");
+      toast.success("Account successfully deleted");
+      
+      // Close dialog and logout after brief delay
+      setShowDeleteDialog(false);
+      setTimeout(async () => {
+        await authClient.signOut();
+        navigate("/");
+      }, 1500);
     } catch (error) {
-      console.error("Failed to delete account:", error);
+      console.error("Failed to delete account:", error, {
+        userId: session.user.id,
+        timestamp: new Date().toISOString(),
+        userAgent: navigator.userAgent
+      });
+      
+      const { message, isRecoverable, shouldCloseDialog } = categorizeError(error);
+      
+      toast.error(message);
+      setLastError({ message, isRecoverable });
+      
+      if (shouldCloseDialog) {
+        setShowDeleteDialog(false);
+        
+        // For auth errors, redirect to sign in
+        if (message.includes('session has expired')) {
+          setTimeout(() => {
+            window.location.reload();
+          }, 2000);
+        }
+      }
     }
   };
 
@@ -107,13 +192,41 @@ export function ManageAccountPage() {
               and remove all of your data including your reviews and ratings.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {/* Show error details if error occurred */}
+          {lastError && (
+            <div className="text-sm text-muted-foreground p-3 bg-muted rounded-md">
+              <p className="font-medium mb-1">Error details:</p>
+              <p>{lastError.message}</p>
+              {lastError.isRecoverable && (
+                <p className="mt-1 text-xs">You can try again or close this dialog.</p>
+              )}
+            </div>
+          )}
+          
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleteAccountMutation.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            
+            {/* Show retry button for recoverable errors */}
+            {lastError?.isRecoverable && (
+              <Button
+                variant="outline"
+                onClick={handleDeleteAccount}
+                disabled={deleteAccountMutation.isPending}
+                className="mr-2"
+              >
+                <RotateCcw className="mr-2 h-4 w-4" />
+                {deleteAccountMutation.isPending ? "Retrying..." : "Retry"}
+              </Button>
+            )}
+            
             <AlertDialogAction
               onClick={handleDeleteAccount}
+              disabled={deleteAccountMutation.isPending}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              Delete Account
+              {deleteAccountMutation.isPending ? "Deleting..." : "Delete Account"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/manage-account-page.tsx
+++ b/src/components/manage-account-page.tsx
@@ -31,6 +31,7 @@ export function ManageAccountPage() {
   const handleDeleteAccount = async () => {
     try {
       await deleteAccountMutation.mutateAsync(session.user.id);
+      await authClient.signOut();
       navigate("/");
     } catch (error) {
       console.error("Failed to delete account:", error);

--- a/src/components/manage-account-page.tsx
+++ b/src/components/manage-account-page.tsx
@@ -154,7 +154,10 @@ export function ManageAccountPage() {
             <div className="pt-4 border-t">
               <div className="flex items-center text-sm text-muted-foreground">
                 <Calendar className="mr-2 h-4 w-4" />
-                Member since {format(new Date(session.user.createdAt), "MMMM d, yyyy")}
+                Member since {session.user.createdAt ? 
+                  format(new Date(session.user.createdAt), "MMMM d, yyyy") : 
+                  "Unknown"
+                }
               </div>
             </div>
           </CardContent>

--- a/src/components/protected-route.tsx
+++ b/src/components/protected-route.tsx
@@ -68,7 +68,7 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
                   Go Back
                 </Button>
                 <p className="text-xs text-center text-muted-foreground">
-                  Sign in with Google to access all features
+                  Sign in to access all features
                 </p>
               </div>
             </CardContent>

--- a/src/components/review-list-item.tsx
+++ b/src/components/review-list-item.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Review } from "../lib/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { formatRelativeTime, formatHoverDate } from "@/lib/utils";
 import HeartIcon from "@/components/ui/heart-icon";
 import { useLikeReview } from "@/lib/queries";
@@ -52,17 +52,11 @@ const ReviewListItem = ({ review, raceName }: ReviewListItemProps) => {
   return (
     <Card data-testid="review-item">
       <CardHeader className="flex flex-row items-center gap-4">
-        <Avatar className="w-12 h-12">
-          <AvatarImage 
-            src={review.avatarUrl} 
-            alt={review.author}
-            referrerPolicy="no-referrer"
-            crossOrigin="anonymous"
-          />
-          {/* When the author's name is missing, use X as the fallback. */}
-          {/* Why X? - x is unknown - math nerd joke */}
-          <AvatarFallback>{review.author?.charAt(0)?.toUpperCase() || 'X'}</AvatarFallback>
-        </Avatar>
+        <UserAvatar 
+          name={review.author}
+          image={review.avatarUrl}
+          className="w-12 h-12"
+        />
         <div className="flex-1">
           <CardTitle>{review.author}</CardTitle>
           {raceName && review.raceId && (

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,155 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button-variants"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,23 @@
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/components/ui/user-avatar.tsx
+++ b/src/components/ui/user-avatar.tsx
@@ -1,0 +1,33 @@
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+
+interface UserAvatarProps {
+  name?: string | null;
+  image?: string | null;
+  className?: string;
+}
+
+export function UserAvatar({ 
+  name, 
+  image, 
+  className
+}: UserAvatarProps) {
+  const getFallback = () => {
+    // When the name is missing, use X as the fallback.
+    // Why X? - x is unknown - math nerd joke
+    return name?.charAt(0)?.toUpperCase() || 'X';
+  };
+
+  return (
+    <Avatar className={className}>
+      {image && (
+        <AvatarImage 
+          src={image} 
+          alt={name || "User avatar"}
+          referrerPolicy="no-referrer"
+          crossOrigin="anonymous"
+        />
+      )}
+      <AvatarFallback>{getFallback()}</AvatarFallback>
+    </Avatar>
+  );
+}

--- a/src/components/ui/user-avatar.tsx
+++ b/src/components/ui/user-avatar.tsx
@@ -1,3 +1,4 @@
+import React, { useMemo } from "react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 
 interface UserAvatarProps {
@@ -6,16 +7,16 @@ interface UserAvatarProps {
   className?: string;
 }
 
-export function UserAvatar({ 
+export const UserAvatar = React.memo(function UserAvatar({ 
   name, 
   image, 
   className
 }: UserAvatarProps) {
-  const getFallback = () => {
+  const fallback = useMemo(() => {
     // When the name is missing, use X as the fallback.
     // Why X? - x is unknown - math nerd joke
     return name?.charAt(0)?.toUpperCase() || 'X';
-  };
+  }, [name]);
 
   return (
     <Avatar className={className}>
@@ -27,7 +28,7 @@ export function UserAvatar({
           crossOrigin="anonymous"
         />
       )}
-      <AvatarFallback>{getFallback()}</AvatarFallback>
+      <AvatarFallback>{fallback}</AvatarFallback>
     </Avatar>
   );
-}
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -85,3 +85,10 @@ export async function unlikeReview(reviewId: string): Promise<{ message: string;
     method: "DELETE",
   });
 }
+
+// User-related API functions
+export async function deleteAccount(userId: string): Promise<void> {
+  return apiRequest<void>(`/api/user/${userId}`, {
+    method: "DELETE",
+  });
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,6 +3,28 @@ import type { Review, Race } from "./types";
 const API_BASE_URL =
   import.meta.env.VITE_BACKEND_URL || "http://localhost:3000";
 
+// Enhanced error class for API errors
+export class ApiError extends Error {
+  public status: number;
+  public statusText: string;
+  public serverMessage?: string;
+  public endpoint?: string;
+
+  constructor(
+    status: number,
+    statusText: string,
+    serverMessage?: string,
+    endpoint?: string
+  ) {
+    super(`API request failed: ${status} ${statusText}`);
+    this.name = 'ApiError';
+    this.status = status;
+    this.statusText = statusText;
+    this.serverMessage = serverMessage;
+    this.endpoint = endpoint;
+  }
+}
+
 // Generic API request function
 async function apiRequest<T>(
   endpoint: string,
@@ -19,15 +41,44 @@ async function apiRequest<T>(
     ...options,
   };
 
-  const response = await fetch(url, config);
+  try {
+    const response = await fetch(url, config);
 
-  if (!response.ok) {
-    throw new Error(
-      `API request failed: ${response.status} ${response.statusText}`
-    );
+    if (!response.ok) {
+      // Try to extract error message from response body
+      let serverMessage: string | undefined;
+      try {
+        const errorBody = await response.text();
+        const parsedError = JSON.parse(errorBody);
+        serverMessage = parsedError.message || parsedError.error || errorBody;
+      } catch {
+        // If parsing fails, use status text
+        serverMessage = response.statusText;
+      }
+
+      throw new ApiError(
+        response.status,
+        response.statusText,
+        serverMessage,
+        endpoint
+      );
+    }
+
+    return response.json();
+  } catch (error) {
+    // Re-throw ApiError as-is
+    if (error instanceof ApiError) {
+      throw error;
+    }
+    
+    // Handle network errors (fetch failures)
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      throw new Error('Network error. Please check your connection and try again.');
+    }
+    
+    // Handle other errors
+    throw new Error('An unexpected error occurred. Please try again.');
   }
-
-  return response.json();
 }
 
 // Race-related API functions

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -139,6 +139,19 @@ export async function unlikeReview(reviewId: string): Promise<{ message: string;
 
 // User-related API functions
 export async function deleteAccount(userId: string): Promise<void> {
+  // Validate userId before making API call
+  if (!userId) {
+    throw new Error("User ID is required");
+  }
+  
+  if (typeof userId !== 'string') {
+    throw new Error("User ID must be a string");
+  }
+  
+  if (!userId.trim()) {
+    throw new Error("User ID cannot be empty or whitespace");
+  }
+
   return apiRequest<void>(`/api/user/${userId}`, {
     method: "DELETE",
   });

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -9,6 +9,7 @@ import {
   deleteReview,
   likeReview,
   unlikeReview,
+  deleteAccount,
 } from "./api";
 
 // Query keys for consistent caching
@@ -178,6 +179,22 @@ export function useLikeReview() {
     onSettled: () => {
       // Always refetch after error or success
       queryClient.invalidateQueries({ queryKey: queryKeys.reviews });
+    },
+  });
+}
+
+// User mutations
+export function useDeleteAccount() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteAccount,
+    onSuccess: () => {
+      // Clear all cached data after account deletion
+      queryClient.clear();
+    },
+    onError: (error) => {
+      console.error("Failed to delete account:", error);
     },
   });
 }

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -82,7 +82,7 @@ test.describe('Dashboard Page', () => {
       const heading = page.getByRole('heading', { name: 'All Reviews' });
       await expect(heading).toBeVisible();
       
-      const subtitle = page.getByText('Browse reviews from all Formula 1 races');
+      const subtitle = page.getByText('Browse reviews from all FORMULA 1 races');
       await expect(subtitle).toBeVisible();
     });
 


### PR DESCRIPTION
## Summary
- Add manage account page at `/manage-account` route with user information display
- Implement account deletion functionality with proper authorization
- Create reusable UserAvatar component to eliminate code duplication across the app

## Changes
### Frontend
- Create `ManageAccountPage` component with account info and delete option
- Add new route `/manage-account` with authentication protection
- Add "Manage Account" link to user dropdown menu
- Create reusable `UserAvatar` component used across multiple components
- Add delete account API function and React Query hook
- Install date-fns for date formatting
- Add alert-dialog component from shadcn/ui for deletion confirmation

### Backend ([PR link](https://github.com/sbappan/boxbox-boxbox-be/pull/3))
- Add DELETE `/api/user/:id` endpoint with authorization checks
- Implement cascade deletion for user data integrity

## Test plan
- [ ] Navigate to /manage-account when logged in
- [ ] Verify user information displays correctly
- [ ] Test delete account flow with confirmation dialog
- [ ] Verify proper authorization (can only delete own account)
- [ ] Check that all user data is removed after deletion
- [ ] Verify UserAvatar component renders correctly in all locations